### PR TITLE
detect log4j2.properties, disable log level if defined

### DIFF
--- a/lib/featureDetection.js
+++ b/lib/featureDetection.js
@@ -46,15 +46,15 @@ function getFeaturesFromBin(path) {
   });
 }
 function getFeaturesFromFile(path) {
-  return access(join(path, 'config', 'log4j2.properties'), F_OK)
+  return access(join(path, 'config', 'logging.yml'), F_OK)
   .then(function () {
     return {
-      log4j2Flag: true
+      usesLoggingYaml: true
     }
   })
   .catch(function () {
     return {
-      log4j2Flag: false
+      usesLoggingYaml: false
     }
   })
 }

--- a/lib/featureDetection.js
+++ b/lib/featureDetection.js
@@ -1,7 +1,10 @@
 var Bluebird = require('bluebird');
 var join = require('path').join;
 var exec = Bluebird.promisify(require('child_process').exec);
+var access = Bluebird.promisify(require('fs').access);
+var F_OK = require('fs').F_OK
 var memoize = require('lodash').memoize;
+var merge = require('lodash').merge;
 
 function getVersionFlag(stdout) {
   // versions 5.0+
@@ -27,9 +30,9 @@ function getConfigVarFlag(stdout) {
   return '-Des.';
 }
 
-exports.getFeatures = memoize(function featureDetect(path) {
-  var cmd = join(path, 'bin', 'elasticsearch');
 
+function getFeaturesFromBin(path) {
+  var cmd = join(path, 'bin', 'elasticsearch');
   return exec(cmd + ' -h')
   .then(function (results) {
     var stdout = results[0];
@@ -37,7 +40,28 @@ exports.getFeatures = memoize(function featureDetect(path) {
 
     return {
       versionFlag: getVersionFlag(stdout, stderr),
-      configVarFlag: getConfigVarFlag(stdout, stderr)
+      configVarFlag: getConfigVarFlag(stdout, stderr),
+
     };
   });
+}
+function getFeaturesFromFile(path) {
+  return access(join(path, 'config', 'log4j2.properties'), F_OK)
+  .then(function () {
+    return {
+      log4j2Flag: true
+    }
+  })
+  .catch(function () {
+    return {
+      log4j2Flag: false
+    }
+  })
+}
+exports.getFeatures = memoize(function featureDetect(path) {
+
+  return Bluebird.join(getFeaturesFromBin(path), getFeaturesFromFile(path), function(featuresFromBin, featuresFromFile) {
+    return merge(featuresFromBin, featuresFromFile);
+  })
+
 });

--- a/lib/node.js
+++ b/lib/node.js
@@ -39,9 +39,13 @@ Node.prototype.start = function (cb) {
     getFeatures(self.path),
   ])
   .spread(function (version, features) {
-    if (features.log4j2Flag) self.emit('log', 'INFO', 'esvm log level configuration disabled')
-
-    return writeTempConfig(self.config, self.logLevel, self.path)
+    return writeTempConfig({
+      config: self.config,
+      logLevel: self.logLevel,
+      esPath: self.path,
+      log: _.bindKey(self, 'emit', 'log'),
+      features: features
+    })
     .then(writeShieldConfig(self.options, version))
     .then(function (configPath) {
       return new Bluebird(function (resolve, reject) {

--- a/lib/node.js
+++ b/lib/node.js
@@ -39,6 +39,8 @@ Node.prototype.start = function (cb) {
     getFeatures(self.path),
   ])
   .spread(function (version, features) {
+    if (features.log4j2Flag) self.emit('log', 'INFO', 'esvm log level configuration disabled')
+
     return writeTempConfig(self.config, self.logLevel, self.path)
     .then(writeShieldConfig(self.options, version))
     .then(function (configPath) {

--- a/lib/writeTempConfig.js
+++ b/lib/writeTempConfig.js
@@ -4,6 +4,7 @@ var rimraf = require('rimraf');
 var fsExtra = require('fs-extra');
 var join = require('path').join;
 var Promise = require('bluebird');
+var noop = require('lodash').noop
 
 var configureLogging = require('./configureLogging');
 var getFeatures = require('./featureDetection').getFeatures;
@@ -20,31 +21,41 @@ process.on('exit', function () {
   }
 });
 
-function getLogConfiguration(dir, configs) {
-  if (configs.log4j2Flag) return []
-  return [remove(join(dir, 'logging.yml')), writeFile(join(dir, 'logging.json'), JSON.stringify(configs.logging), 'utf8')]
+function writeLogConfiguration(dir, configs, log) {
+  if (!configs.usesLoggingYaml) {
+    log('INFO', 'esvm log level configuration disabled');
+    return Promise.resolve();
+  }
+  return Promise.all[
+    remove(join(dir, 'logging.yml')),
+    writeFile(join(dir, 'logging.json'), JSON.stringify(configs.logging), 'utf8')
+  ];
 }
 
-module.exports = function (config, logLevel, esPath) {
+module.exports = function (options) {
+  var logLevel = options.logLevel;
+  var esPath = options.esPath;
+  var config = options.config;
+  var log = options.log || noop;
+  var features = options.features;
+
   return mkdirTemp({prefix: 'libesvm-'}).then(function createConfig(dir) {
     return Promise.attempt(function () {
       return copy(join(esPath, 'config'), dir);
     })
-    .then(function() {
-      return getFeatures(esPath);
-    })
-    .then(function (features) {
+    .then(function () {
       return Promise.props({
         es: configureLogging.enforceEsvmMinimumLevels(config, logLevel),
-        logging: features.log4j2Flag ? null : configureLogging.readAndSetLevel(join(dir, 'logging.yml'), logLevel),
-        log4j2Flag: features.log4j2Flag
+        logging: features.usesLoggingYaml ? configureLogging.readAndSetLevel(join(dir, 'logging.yml'), logLevel): null,
+        usesLoggingYaml: features.usesLoggingYaml
       });
     })
     .then(function (configs) {
       return Promise.all([
         remove(join(dir, 'elasticsearch.yml')),
         writeFile(join(dir, 'elasticsearch.json'), JSON.stringify(configs.es), 'utf8'),
-      ].concat(getLogConfiguration(dir, configs)));
+      ])
+      .then(writeLogConfiguration(dir, configs, log));
     })
     .thenReturn(dir);
   });

--- a/lib/writeTempConfig.js
+++ b/lib/writeTempConfig.js
@@ -6,6 +6,7 @@ var join = require('path').join;
 var Promise = require('bluebird');
 
 var configureLogging = require('./configureLogging');
+var getFeatures = require('./featureDetection').getFeatures;
 
 var writeFile = Promise.promisify(fs.writeFile);
 var mkdirTemp = Promise.promisify(temp.mkdir);
@@ -19,24 +20,31 @@ process.on('exit', function () {
   }
 });
 
+function getLogConfiguration(dir, configs) {
+  if (configs.log4j2Flag) return []
+  return [remove(join(dir, 'logging.yml')), writeFile(join(dir, 'logging.json'), JSON.stringify(configs.logging), 'utf8')]
+}
+
 module.exports = function (config, logLevel, esPath) {
   return mkdirTemp({prefix: 'libesvm-'}).then(function createConfig(dir) {
     return Promise.attempt(function () {
       return copy(join(esPath, 'config'), dir);
     })
-    .then(function () {
+    .then(function() {
+      return getFeatures(esPath);
+    })
+    .then(function (features) {
       return Promise.props({
         es: configureLogging.enforceEsvmMinimumLevels(config, logLevel),
-        logging: configureLogging.readAndSetLevel(join(dir, 'logging.yml'), logLevel),
+        logging: features.log4j2Flag ? null : configureLogging.readAndSetLevel(join(dir, 'logging.yml'), logLevel),
+        log4j2Flag: features.log4j2Flag
       });
     })
     .then(function (configs) {
       return Promise.all([
         remove(join(dir, 'elasticsearch.yml')),
-        remove(join(dir, 'logging.yml')),
         writeFile(join(dir, 'elasticsearch.json'), JSON.stringify(configs.es), 'utf8'),
-        writeFile(join(dir, 'logging.json'), JSON.stringify(configs.logging), 'utf8'),
-      ]);
+      ].concat(getLogConfiguration(dir, configs)));
     })
     .thenReturn(dir);
   });

--- a/test/writeTempConfig.js
+++ b/test/writeTempConfig.js
@@ -36,7 +36,14 @@ describe('write temp config', function () {
   });
 
   it('should create a temp folder with configs', function() {
-    return writeTempConfig({foo: 'bar'}, 'INFO', mockConfigFolder)
+    return writeTempConfig({
+      config: {foo: 'bar'},
+      logLevel: 'INFO',
+      esPath: mockConfigFolder,
+      features: {
+        usesLoggingYaml: true
+      }
+    })
     .then(function(path) {
       return fs.readdirAsync(path);
     })


### PR DESCRIPTION
Elasticsearch recently upgraded from log4j to log4j2.  As part of this upgrade, the logging.yml wrapper around log4j properties was removed and a raw properties file is exposed instead.   This PR adds feature detection for the log file type, and disables log level configuration if using a log4j2 properties file.  This is a partial fix to get esvm running, a full solution will require parsing the new configuration format.