### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -8,7 +8,7 @@ var install        = require('./install');
 var resolvePath    = require('./resolvePath');
 var installPlugins = require('./installPlugins');
 var resolveVersion = require('./resolveVersion');
-var uuid           = require('node-uuid');
+var uuid           = require('uuid');
 
 var exec           = Promise.promisify(child_process.exec);
 var rimraf         = Promise.promisify(require('rimraf'));

--- a/lib/node.js
+++ b/lib/node.js
@@ -14,7 +14,7 @@ var writeTempConfig = require('./writeTempConfig');
 var writeShieldConfig = require('./writeShieldConfig');
 var isWindows = /^win/.test(process.platform);
 var getActualVersion = require('./getActualVersion');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var getFeatures = require('./featureDetection').getFeatures;
 
 var startOfStackTraceRE = /^Exception in thread /;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "lodash.snakecase": "^4.1.1",
     "mkdirp": "~0.5.0",
     "moment": "^2.7.0",
-    "node-uuid": "^1.4.7",
     "properties-parser": "^0.2.3",
     "rcloader": "^0.1.4",
     "request": "~2.65.0",
@@ -45,7 +44,8 @@
     "split": "~0.3.2",
     "tar": "~2.2.1 ",
     "temp": "^0.8.0",
-    "through2": "~0.6.3"
+    "through2": "~0.6.3",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.