### PR TITLE
Add install command for 6.x plugins

### DIFF
--- a/lib/installPlugin.js
+++ b/lib/installPlugin.js
@@ -36,7 +36,7 @@ function create2xPluginInstallCommand(path, plugin, features) {
   return cmd;
 }
 
-function create5xPluginInstallCommand(path, plugin, features) {
+function createLatestPluginInstallCommand(path, plugin, features) {
   var cmd = join(path, 'bin', 'elasticsearch-plugin');
   cmd += ' install ';
   if (_.isPlainObject(plugin)) {
@@ -64,8 +64,8 @@ function installCommand(path, plugin) {
       return create2xPluginInstallCommand(path, plugin, features);
     }
 
-    if (semver.satisfies(version, '>=5.0.0-alpha1 || 3.x')) {
-      return create5xPluginInstallCommand(path, plugin, features);
+    if (semver.satisfies(version, '>=6.0.0-alpha1 || >=5.0.0-alpha1 || 3.x')) {
+      return createLatestPluginInstallCommand(path, plugin, features);
     }
 
     throw new Error('Not sure how to install plugins for version ' + version);


### PR DESCRIPTION
```
> semver.satisfies('6.0.0-alpha1', '>=5.0.0-alpha1')
false
> semver.satisfies('6.0.0-alpha1', '>=6.0.0-alpha1')
true
> semver.satisfies('6.0.0', '>=5.0.0-alpha1')
true
```