### PR TITLE
Fix path.conf usage in 2.x

### DIFF
--- a/lib/featureDetection.js
+++ b/lib/featureDetection.js
@@ -32,7 +32,7 @@ function getConfigVarFlag(stdout) {
 }
 
 function getPathConfigFlag(stdout) {
-  if (stdout.indexOf('-Dproperty=value') > -1) {
+  if (stdout.indexOf('--property=value') > -1) {
     return '--path.conf'
   }
 

--- a/lib/featureDetection.js
+++ b/lib/featureDetection.js
@@ -32,7 +32,7 @@ function getConfigVarFlag(stdout) {
 }
 
 function getPathConfigFlag(stdout) {
-  if (stdout.indexOf(' --path.conf ') > -1) {
+  if (stdout.indexOf('-Dproperty=value') > -1) {
     return '--path.conf'
   }
 


### PR DESCRIPTION
```
$ esvm -b 2.x
Running "esvm:dev:keepalive" (esvm) task
starting up "dev" cluster
Keeping elasticsearch alive, to shutdown press command/control+c
INFO -  - cluster - Downloading & installing from "2.x" branch.
INFO -  - cluster - Installing plugins
INFO -  - cluster - Starting 1 nodes
INFO - ? - ? - ERROR: Parameter [-Epath.conf=/var/folders/2b/b_c0rjw92lq6ktb9cjns49680000gn/T/libesvm-11778-12825-1xsi7ve.84obt9]does not start with --
```

6.0
```
starts elasticsearch

Option                Description                                               
------                -----------                                               
-E <KeyValuePair>     Configure a setting                                       
-V, --version         Prints elasticsearch version information and exits        
-d, --daemonize       Starts Elasticsearch in the background                    
-h, --help            show help                                                 
-p, --pidfile <Path>  Creates a pid file in the specified path on start         
-q, --quiet           Turns off standard output/error streams logging in console
-s, --silent          show minimal output                                       
-v, --verbose         show verbose output                                       
```

5.5
```
starts elasticsearch

Option                Description                                              
------                -----------                                              
-E <KeyValuePair>     Configure a setting                                      
-V, --version         Prints elasticsearch version information and exits       
-d, --daemonize       Starts Elasticsearch in the background                   
-h, --help            show help                                                
-p, --pidfile <Path>  Creates a pid file in the specified path on start        
-q, --quiet           Turns off standard ouput/error streams logging in console
-s, --silent          show minimal output                                      
-v, --verbose         show verbose output                                      
```

2.4
```

NAME

    start - Start Elasticsearch

SYNOPSIS

    elasticsearch start

DESCRIPTION

    This command starts Elasticsearch. You can configure it to run in the foreground, write a pid file
    and configure arbitrary options that override file-based configuration.

OPTIONS

    -h,--help                    Shows this message

    -p,--pidfile <pidfile>       Creates a pid file in the specified path on start

    -d,--daemonize               Starts Elasticsearch in the background

    -Dproperty=value             Configures an Elasticsearch specific property, like -Dnetwork.host=127.0.0.1

    --property=value             Configures an elasticsearch specific property, like --network.host 127.0.0.1
    --property value

    NOTE: The -d, -p, and -D arguments must appear before any --property arguments.
```