### PR TITLE
Implement cache.clear()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ node_modules
 cache.json
 .releases
 .DS_Store
+yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
 node_js:
-  - "stable"
-  - "4.1"
-  - "4.0"
-  - "0.12"
+  - "8"
+  - "6"

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var loader = module.exports;
 var Cluster = require('./lib/cluster');
+var cache = require('./lib/cache');
 
 /**
  * var options = {
@@ -8,7 +9,7 @@ var Cluster = require('./lib/cluster');
  *   plugins: ['elasticsearch/marvel/latest'],
  *   purge: true, // Purge the data directory
  *   fresh: true, // Download a fresh copy
- *   loggerStreams: [ process.stdout ], // Bunyan Streams 
+ *   loggerStreams: [ process.stdout ], // Bunyan Streams
  *   config: {
  *     'cluster.name': 'My Test Cluster',
  *     'http.port': 9200
@@ -26,3 +27,10 @@ loader.createCluster = function (options, cb) {
   return cluster;
 };
 
+/**
+ * Clear the libesvm cache file
+ * @return {[type]} [description]
+ */
+loader.clearCache = function () {
+  return cache.clear()
+}

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var Promise = require('bluebird');
 var readFileAsync = Promise.promisify(fs.readFile);
 var writeFileAsync = Promise.promisify(fs.writeFile);
+var unlinkAsync = Promise.promisify(fs.unlink);
 var os = require('os');
 var join = require('path').join;
 var version = require('../package.json').version;
@@ -71,3 +72,12 @@ var save = cache.save = function (cb) {
   var data = JSON.stringify(cache.data || {});
   return writeFileAsync(cache.source, data).nodeify(cb);
 };
+
+/**
+ * Clear the cache data
+ * @param  {Function} [cb]
+ * @return {Promise}
+ */
+cache.clear = function (cb) {
+  return unlinkAsync(cache.source).nodeify(cb);
+}

--- a/lib/freshInstall.js
+++ b/lib/freshInstall.js
@@ -1,15 +1,27 @@
 var purge = require('./purge');
+var cache = require('./cache');
 var Promises = require('bluebird');
 /**
  * Install a fresh copy?
- * @param {boolean} fresh Install a fresh copy or not 
+ * @param {boolean} fresh Install a fresh copy or not
  * @param {stirng} dest description
  * @param {function} cb The node style callback
  * @returns {Promise}
  */
 module.exports = function (fresh, dest, cb) {
-  return Promises.resolve(fresh && purge(dest) || dest)
-  .then(function () {
-    return dest; 
-  }).nodeify(cb); 
+  return Promises
+    .attempt(function () {
+      if (!fresh) {
+        return;
+      }
+
+      return purge(dest)
+        .then(function () {
+          return cache.clear()
+        })
+    })
+    .then(function () {
+      return dest;
+    })
+    .nodeify(cb);
 };

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "cli-color": "^0.3.2",
     "connect": "^3.3.5",
     "del": "^2.2.2",
-    "mkdirp": "^0.5.1",
     "mocha": "*",
     "progress": "^1.1.7",
     "sinon": "^1.14.1"

--- a/test/cache.js
+++ b/test/cache.js
@@ -27,22 +27,20 @@ describe('Cache', function() {
       temp.cleanup(done);
     });
 
-    it('should return valid data', function(done) {
-      cache.get('bar').then(function (val) {
+    it('should return valid data', function() {
+      return cache.get('bar').then(function (val) {
         expect(val).to.equal('foo');
-        done();
       });
     });
 
-    it('should return undefined for invalid data', function(done) {
-      cache.get('monkey').then(function (val) {
+    it('should return undefined for invalid data', function() {
+      return cache.get('monkey').then(function (val) {
         expect(val).to.be.an('undefined');
-        done();
       });
     });
 
     it('should set a new value', function() {
-      cache.set('name', 'test').then(function () {
+      return cache.set('name', 'test').then(function () {
         return cache.get('name');
       })
       .then(function (val) {
@@ -50,5 +48,23 @@ describe('Cache', function() {
       });
     });
 
+    it('should allow clearing the cache', function () {
+      return cache.set('foo', 'bar')
+        .then(function () {
+          return cache.get('foo')
+        })
+        .then(function (value) {
+          expect(value).to.equal('bar')
+        })
+        .then(function () {
+          return cache.clear();
+        })
+        .then(function () {
+          return cache.get('foo')
+        })
+        .then(function (value) {
+          expect(value).to.equal(undefined)
+        })
+    })
   });
 });


### PR DESCRIPTION
This updates the libesvm cache with a `clear()` method, which wipes the cache from disk. It is then used when a fresh install is requested, and exposed at the top level API for the `esvm` cli to use if necessary.