### PR TITLE
Ignoring ENOENT on cache.clear

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -85,9 +85,8 @@ cache.clear = function (cb) {
     }
 
     // swalling the error if it's a file does not exist error
-    if (err.code === 'ENOENT') {
-      cb();
-      return;
+    if (err && err.code === 'ENOENT') {
+      return cb();
     }
 
     return cb(err);

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -78,7 +78,7 @@ var save = cache.save = function (cb) {
  * @return {Promise}
  */
 cache.clear = function (cb) {
-  return fs.unlink(cache.source, function (err) {
+  fs.unlink(cache.source, function (err) {
     // if we weren't given a callback, it doesn't matter
     if (!cb) {
       return;

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -3,7 +3,6 @@ var fs = require('fs');
 var Promise = require('bluebird');
 var readFileAsync = Promise.promisify(fs.readFile);
 var writeFileAsync = Promise.promisify(fs.writeFile);
-var unlinkAsync = Promise.promisify(fs.unlink);
 var os = require('os');
 var join = require('path').join;
 var version = require('../package.json').version;
@@ -79,5 +78,18 @@ var save = cache.save = function (cb) {
  * @return {Promise}
  */
 cache.clear = function (cb) {
-  return unlinkAsync(cache.source).nodeify(cb);
+  return fs.unlink(cache.source, function (err) {
+    // if we weren't given a callback, it doesn't matter
+    if (!cb) {
+      return;
+    }
+
+    // swalling the error if it's a file does not exist error
+    if (err.code === 'ENOENT') {
+      cb();
+      return;
+    }
+
+    return cb(err);
+  });
 }


### PR DESCRIPTION
https://github.com/elastic/libesvm/pull/50 introduced a bug where if the cache.json doesn't exist, the unlink call was returning an `ENOENT` error which wasn't being ignored.