### PR TITLE
Chore: update request and uuid

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -8,7 +8,7 @@ var install        = require('./install');
 var resolvePath    = require('./resolvePath');
 var installPlugins = require('./installPlugins');
 var resolveVersion = require('./resolveVersion');
-var uuid           = require('node-uuid');
+var uuid           = require('uuid');
 
 var exec           = Promise.promisify(child_process.exec);
 var rimraf         = Promise.promisify(require('rimraf'));

--- a/lib/node.js
+++ b/lib/node.js
@@ -14,7 +14,7 @@ var writeTempConfig = require('./writeTempConfig');
 var writeShieldConfig = require('./writeShieldConfig');
 var isWindows = /^win/.test(process.platform);
 var getActualVersion = require('./getActualVersion');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var getFeatures = require('./featureDetection').getFeatures;
 
 var startOfStackTraceRE = /^Exception in thread /;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node-uuid": "^1.4.7",
     "properties-parser": "^0.2.3",
     "rcloader": "^0.1.4",
-    "request": "~2.65.0",
+    "request": "^2.83.0",
     "rimraf": "~2.2.8",
     "semver": "~4.3.6",
     "split": "~0.3.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "lodash.snakecase": "^4.1.1",
     "mkdirp": "~0.5.0",
     "moment": "^2.7.0",
-    "node-uuid": "^1.4.7",
     "properties-parser": "^0.2.3",
     "rcloader": "^0.1.4",
     "request": "^2.83.0",
@@ -45,7 +44,8 @@
     "split": "~0.3.2",
     "tar": "~2.2.1 ",
     "temp": "^0.8.0",
-    "through2": "~0.6.3"
+    "through2": "~0.6.3",
+    "uuid": "^3.1.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
This fixes the following npm warnings when install `libesvm`:

```
libesvm > node-uuid@1.4.8: Use uuid module instead
libesvm > request > node-uuid@1.4.8: Use uuid module instead
libesvm > request > tough-cookie@2.2.2: ReDoS vulnerability parsing Set-Cookie https://nodesecurity.io/advisories/130
```

- Bump `request` to 2.83.0
- Replace `node-uuid` with `uuid` 3.1.0
